### PR TITLE
update black and grey hex

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@honehealth/jutsu",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "author": "Hone Health <info@honehealth.com>",
   "repository": {
     "type": "git",

--- a/src/colors.ts
+++ b/src/colors.ts
@@ -13,15 +13,15 @@ export default {
   whitePure: '#ffffff',
   red: {
     default: '#f52c5e',
-    light: "#ffeaef"
+    light: '#ffeaef',
   },
   orange: {
     default: '#f6752d',
   },
   yellow,
   green: {
-    default: '#1e9c5b', 
-    light: "#cbf2df",
+    default: '#1e9c5b',
+    light: '#cbf2df',
   },
   grayLight: '#f1f0ef',
   grayMid: {
@@ -33,7 +33,7 @@ export default {
     lightest: '#fafaf7',
   },
   grayDark: {
-    default: '#605b52',
+    default: '#6D6D6D',
     hover: '#7f7b74',
     depressed: '#9e9b95',
     light: '#dddcd8',

--- a/src/colors.ts
+++ b/src/colors.ts
@@ -41,7 +41,7 @@ export default {
     lightest: '#f4f4f2',
   },
   black: {
-    default: '#0e0b20',
+    default: '#202020',
     hover: '#3e3b4c',
     depressed: '#6d6b77',
     light: '#ccccce',


### PR DESCRIPTION
Updates default black and dark grey to colors used in new sub checkout designs

https://getpeaktoday.slack.com/archives/C090DE9AZPZ/p1754408473807969